### PR TITLE
Add pod setup after installing cocoa pods

### DIFF
--- a/native-script.rb
+++ b/native-script.rb
@@ -135,7 +135,7 @@ execute("mkdir -p ~/.cocoapods", "There was a problem in creating ~/.cocoapods d
 # which works with Ruby 2.0 that comes as the macOS default, so these two installations should be in this order.
 # For more information see: https://github.com/CocoaPods/Xcodeproj/pull/393#issuecomment-231055159
 install("CocoaPods", "Installing CocoaPods... This might take some time, please, be patient.", 'gem install cocoapods -V', true)
-install("CocoaPods", "Setup CocoaPods... This might take some time, please, be patient.", 'pod setup', true)
+install("CocoaPods", "Setup CocoaPods... This might take some time, please, be patient.", 'pod setup', false)
 install("xcodeproj", "Installing xcodeproj... This might take some time, please, be patient.", 'gem install xcodeproj -V', true)
 
 puts "Configuring your system for Android development... This might take some time, please, be patient."

--- a/native-script.rb
+++ b/native-script.rb
@@ -135,6 +135,7 @@ execute("mkdir -p ~/.cocoapods", "There was a problem in creating ~/.cocoapods d
 # which works with Ruby 2.0 that comes as the macOS default, so these two installations should be in this order.
 # For more information see: https://github.com/CocoaPods/Xcodeproj/pull/393#issuecomment-231055159
 install("CocoaPods", "Installing CocoaPods... This might take some time, please, be patient.", 'gem install cocoapods -V', true)
+install("CocoaPods", "Setup CocoaPods... This might take some time, please, be patient.", 'pod setup', true)
 install("xcodeproj", "Installing xcodeproj... This might take some time, please, be patient.", 'gem install xcodeproj -V', true)
 
 puts "Configuring your system for Android development... This might take some time, please, be patient."


### PR DESCRIPTION
Currently `tns doctor` fails when check cocoa pods.
This will make doctor happy.