### PR TITLE
chore: update build-tools to 27.0.3

### DIFF
--- a/native-script.ps1
+++ b/native-script.ps1
@@ -156,8 +156,8 @@ $androidExecutable = [io.path]::combine($env:ANDROID_HOME, "tools", "bin", "sdkm
 
 Write-Host -ForegroundColor DarkYellow "Setting up Android SDK platform-tools..."
 echo y | cmd /c "$androidExecutable" "platform-tools"
-Write-Host -ForegroundColor DarkYellow "Setting up Android SDK build-tools;25.0.2..."
-echo y | cmd /c "$androidExecutable" "build-tools;25.0.2"
+Write-Host -ForegroundColor DarkYellow "Setting up Android SDK build-tools;27.0.3..."
+echo y | cmd /c "$androidExecutable" "build-tools;27.0.3"
 Write-Host -ForegroundColor DarkYellow "Setting up Android SDK platforms;android-25..."
 echo y | cmd /c "$androidExecutable" "platforms;android-25"
 Write-Host -ForegroundColor DarkYellow "Setting up Android SDK extras;android;m2repository..."

--- a/native-script.rb
+++ b/native-script.rb
@@ -146,7 +146,7 @@ error_msg = "There seem to be some problems with the Android configuration"
 sdk_manager = File.join(ENV["ANDROID_HOME"], "tools", "bin", "sdkmanager")
 execute("echo y | #{sdk_manager} \"platform-tools\"", error_msg)
 execute("echo y | #{sdk_manager} \"tools\"", error_msg)
-execute("echo y | #{sdk_manager} \"build-tools;25.0.2\"", error_msg)
+execute("echo y | #{sdk_manager} \"build-tools;27.0.3\"", error_msg)
 execute("echo y | #{sdk_manager} \"platforms;android-25\"", error_msg)
 execute("echo y | #{sdk_manager} \"extras;android;m2repository\"", error_msg)
 execute("echo y | #{sdk_manager} \"extras;google;m2repository\"", error_msg)


### PR DESCRIPTION
Update build tools to 27.0.3.

With latest android runtime we use gradle 4.4 and it downloads build-tools-27.0.3 at some point. 
Then CLI try to use them, but license is not accepted (because they are downloaded by gradle during build). 
Result is failing android build.

This will install latest build tools (and accept the license), so users will not encounter the issue described above.